### PR TITLE
Deactivate colors in lessc output.

### DIFF
--- a/LESS-normal.sublime-build-choice
+++ b/LESS-normal.sublime-build-choice
@@ -1,5 +1,5 @@
 {
-    "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.css", "--verbose"],
+    "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.css", "--verbose", "--no-color"],
     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
     "selector": "source.css.less",
 
@@ -16,7 +16,7 @@
     "variants": [
         {
             "name": "Minify",
-            "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.min.css", "-x", "--verbose"],
+            "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.min.css", "-x", "--verbose", "--no-color"],
 
             "osx":
             {

--- a/LESS-rewriteDir.sublime-build-choice
+++ b/LESS-rewriteDir.sublime-build-choice
@@ -1,5 +1,5 @@
 {
-    "cmd": ["lessc", "$file", "${file_path/(.*)less(.*)/\\1css\\2/}/${file_base_name}.css", "--verbose"],
+    "cmd": ["lessc", "$file", "${file_path/(.*)less(.*)/\\1css\\2/}/${file_base_name}.css", "--verbose", "--no-color"],
     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
     "selector": "source.css.less",
 
@@ -16,7 +16,7 @@
     "variants": [
         {
             "name": "Minify",
-            "cmd": ["lessc", "$file", "${file_path/(.*)less(.*)/\\1css\\2/}/${file_base_name}.min.css", "-x", "--verbose"],
+            "cmd": ["lessc", "$file", "${file_path/(.*)less(.*)/\\1css\\2/}/${file_base_name}.min.css", "-x", "--verbose", "--no-color"],
 
             "osx":
             {


### PR DESCRIPTION
Lessc outputs colors when there are syntax errors on building.

Since the sublime console doesn't seem to play nice with colors, this patch passes the `--no-color` option to lessc to surpress colored output. 