### PR TITLE
Disable colour to fix escape codes showing in error messages

### DIFF
--- a/LESS.sublime-build
+++ b/LESS.sublime-build
@@ -1,5 +1,5 @@
 {
-    "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.css", "--verbose"],
+    "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.css", "--verbose", "--no-color"],
     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
     "selector": "source.css.less",
 
@@ -16,7 +16,7 @@
     "variants": [
         {
             "name": "Minify",
-            "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.min.css", "-x", "--verbose"],
+            "cmd": ["lessc", "$file", "${file_path}/${file_base_name}.min.css", "-x", "--verbose", "--no-color"],
 
             "osx":
             {


### PR DESCRIPTION
Colour codes were making my error messages difficult to read. Not sure if the switches are the same for Windows/OSX?
